### PR TITLE
Added .html to links to allow harp compile

### DIFF
--- a/public/_shared_assets/header.jade
+++ b/public/_shared_assets/header.jade
@@ -9,4 +9,7 @@
     #topnav
         ul(class='nav')
             for nav, slug in public._data.nav
-                li: a(href="/#{ slug }")= nav.title
+                if slug
+                    li: a(href="/#{ slug }.html")= nav.title
+                else
+                    li: a(href="/")= nav.title

--- a/public/archive.jade
+++ b/public/archive.jade
@@ -1,7 +1,7 @@
 h1 Previous meetups
 ul
     for meetup, slug in public.meetup._data.archive
-       li: a(href="/archive##{ slug }")= slug
+       li: a(href="/archive.html##{ slug }")= slug
 hr
 for meetup, slug in public.meetup._data.archive
     a(name="#{ slug }")

--- a/public/topics.jade
+++ b/public/topics.jade
@@ -1,5 +1,5 @@
 mixin meetup_short(meetup, slug)
-    h2: a(href='/meetup/#{ slug }') Meetup: #{ meetup.title }
+    h2: a(href='/meetup/#{ slug }.html') Meetup: #{ meetup.title }
     ul
         if meetup.schedule
             each topic, number in meetup.schedule
@@ -8,7 +8,7 @@ mixin meetup_short(meetup, slug)
                     br
                     | by #{ topic.speaker },
                     if topic.video
-                        a(href='/videos##{ slug }-#{ number }')  Video
+                        a(href='/videos.html##{ slug }-#{ number }')  Video
 
 for meetup, slug in public.meetup._data.archive
     if meetup.title


### PR DESCRIPTION
Laut https://github.com/sintaxi/harp/issues/173 muss man für die Nutzung mit harp compile die Endung .html manuell an alle Links anhängen.
