### PR TITLE
map refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 *.iml
+www
+

--- a/public/_layout.jade
+++ b/public/_layout.jade
@@ -5,7 +5,7 @@ html
         title MNUG - Munich NodeJS User Group
         link(rel='stylesheet', href='/assets/layout.css')
         link(rel='stylesheet', href='/assets/navi.css')
-        script(src='http://maps.google.com/maps?file=api&amp;v=2&amp;key=AIzaSyDvsGfCR2q58do1B2Hy1efNzpK306VdPLk')
+        script(src='https://maps.googleapis.com/maps/api/js')
         script(src='/js/drawMap.js')
     body
         != partial("/_shared_assets/header.jade")

--- a/public/_shared_assets/places/tng.md
+++ b/public/_shared_assets/places/tng.md
@@ -7,6 +7,5 @@ by S-Bahn: Unterföhring (S8)
 by Bus: Linie 233, Haltestelle Betastraße  
 by Car: There are parking areas on the left side
 
-<div id="map" class="map" style="width: 500px; height:500px; position: relative; background-color: rgb(229, 227, 223);">
+<div id="map" class="map" data-locationtext="TNG<br/>Betastraße 13a<br/>85774 Unterföhring" data-locationlatlng="48.187663,11.654348" style="width: 500px; height:500px; position: relative; background-color: rgb(229, 227, 223);">
 </div>
-<script type="text/javascript">drawMap();</script>

--- a/public/js/drawMap.js
+++ b/public/js/drawMap.js
@@ -1,34 +1,32 @@
-/*var key = {
-    'mnug.de': 'AIzaSyDvsGfCR2q58do1B2Hy1efNzpK306VdPLk',
-    'www.mnug.de': 'AIzaSyDvsGfCR2q58do1B2Hy1efNzpK306VdPLk'
-}[document.location.host];
 
-document.write(
-    '<script src="http://maps.google.com/maps?file=api&amp;v=2&amp;key=AIzaSyDvsGfCR2q58do1B2Hy1efNzpK306VdPLk" type="text/javascript"><\/script>');
-*/
-//<![CDATA[
 
-function drawMap() {
-    if (GBrowserIsCompatible()) {
-        var map = new GMap2(document.getElementById("map"));
+function initialize() {
+    var mapCanvas = document.getElementById('map');
+    if (mapCanvas){
+	    var latLng=mapCanvas.getAttribute('data-locationlatlng').split(',')
+	    var myLatlng = new google.maps.LatLng(latLng[0], latLng[1]);
+	    var mapOptions = {
+		center: myLatlng,
+		zoom: 15,
+		mapTypeId: google.maps.MapTypeId.ROADMAP
+	    }
 
-        map.addControl(new GSmallMapControl());
-        map.addControl(new GOverviewMapControl());
-        map.addControl(new GScaleControl());
-        map.setCenter(new GLatLng(48.187663, 11.654348), 15, G_NORMAL_MAP);
+	    var infowindow = new google.maps.InfoWindow({
+		content: mapCanvas.getAttribute('data-locationtext')
+	    });
 
-        var praxisll = new GLatLng(48.187663, 11.654348);
-        var praxismark = new GMarker(praxisll);
-        map.addOverlay(praxismark);
+	    var map = new google.maps.Map(mapCanvas, mapOptions)
 
-        var praxisdesc = "<div style='font-weight:bold;border-bottom:1px solid #cccccc;padding-bottom:5px;font-color:#000000'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TNG<br/>"
-            + "Betastraße 13a<br />"
-            + "85774 Unterföhring<br /><br /></div>"
-        praxismark.openInfoWindowHtml(praxisdesc);
+	    var marker = new google.maps.Marker({
+		position: myLatlng,
+		map: map
+	    });
 
-        GEvent.addListener(praxismark, "click", function () {
-            praxismark.openInfoWindowHtml(praxisdesc);
-        });
+	    google.maps.event.addListener(marker, 'click', function() {
+		infowindow.open(map,marker);
+	    });
     }
 }
-//]]>
+
+google.maps.event.addDomListener(window, 'load', initialize);
+

--- a/public/meetup/2013_10_10.ejs
+++ b/public/meetup/2013_10_10.ejs
@@ -60,5 +60,4 @@ Balanstrasse 73<br/>
    by U-Bahn: Karl-Preis-Platz (U2)<br />
    by Bus: Linie 145, Haltestelle Karl-Preis-Platz<br />
 </p>
-<div id="map" class="map" style="width: 0px; height:0px; position: relative; background-color: rgb(229, 227, 223);">
-</div>
+

--- a/public/meetup/2014_10_13.ejs
+++ b/public/meetup/2014_10_13.ejs
@@ -54,5 +54,4 @@ München</br
     <strong>We wish you a nice journey:</strong><br />
    by S-Bahn: St.-Martin-Strasse (S3, S7)<br />
 </p>
-<div id="map" class="map" style="width: 0px; height:0px; position: relative; background-color: rgb(229, 227, 223);">
-</div>
+

--- a/public/meetup/2015_07_30.md
+++ b/public/meetup/2015_07_30.md
@@ -60,6 +60,5 @@ by S-Bahn: Unterföhring (S8)
 by Bus: Linie 233, Haltestelle Betastraße  
 by Car: There are parking areas on the left side
 
-<div id="map" class="map" style="width: 500px; height:500px; position: relative; background-color: rgb(229, 227, 223);">
+<div id="map" class="map" data-locationtext="TNG<br/>Betastraße 13a<br/>85774 Unterföhring" data-locationlatlng="48.187663,11.654348" style="width: 500px; height:500px; position: relative; background-color: rgb(229, 227, 223);">
 </div>
-<script type="text/javascript">drawMap();</script>


### PR DESCRIPTION
- replace Google Maps API v2 with current version
- use data attributes to provide location data as parameter

Instead of refactoring the map stuff it would probably make more sense to replace it with a link to Google Maps, as on mobile phones these links usually offer to use the native Google Maps app which has more features than embedded web maps.
